### PR TITLE
Exit application `<ESC>` press

### DIFF
--- a/metaballs.v
+++ b/metaballs.v
@@ -47,6 +47,11 @@ fn event(mut e gg.Event, mut app App) {
 		app.mouse_x = e.mouse_x
 		app.mouse_y = e.mouse_y
 	}
+	if e.typ == .key_down {
+		if e.key_code == .escape {
+			app.gg.quit()
+		}
+	}
 }
 
 fn init(mut app App) {


### PR DESCRIPTION
This PR will make the application exit when user presses the `<ESC>` key on the keyboard.
That way users with single monitors will be able to exit the app more easily.